### PR TITLE
fix: pr closed without merge

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,7 @@
 - [ ] Gerar changelog retroativo
 - [ ] Refatorações
     - [ ] Retornar erros corretamente
+    - [ ] Renomear funções e variáveis corretamente
 - [x] Escolher nome da action
 - [ ] Adicionar testes unitários e integrados
 - [ ] Adicionar fluxo de CI/CD


### PR DESCRIPTION
It was returning an unhandled error when filtering the ones to which were closed and not merged. So, it was necessary to add validation for these cases.